### PR TITLE
fixes #21: use setImmediate in _setTimeout when millis is zero

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -108,6 +108,14 @@ later' :: forall e a. Number -> Aff e a -> Aff e a
 Runs the specified asynchronous computation later, by the specified
 number of milliseconds.
 
+#### `finally`
+
+``` purescript
+finally :: forall e a b. Aff e a -> Aff e b -> Aff e a
+```
+
+Compute `aff1`, followed by `aff2` regardless of whether `aff1` terminated successfully.
+
 #### `forkAff`
 
 ``` purescript
@@ -262,6 +270,9 @@ instance monoidCanceler :: Monoid (Canceler e)
 
 ## Module Control.Monad.Aff.AVar
 
+
+A low-level primitive for building asynchronous code.
+
 #### `AVAR`
 
 ``` purescript
@@ -364,6 +375,11 @@ from writing `liftEff $ trace x` everywhere.
 
 
 ## Module Control.Monad.Aff.Par
+
+
+A newtype over `Aff` that provides `Applicative` instances that run in 
+parallel. This is useful, for example, if you want to run a whole bunch 
+of AJAX requests at the same time, rather than sequentially.
 
 #### `Par`
 

--- a/MODULES.md
+++ b/MODULES.md
@@ -8,7 +8,7 @@
 data Aff :: # ! -> * -> *
 ```
 
-An asynchronous computation with effects `e`. The computation either 
+An asynchronous computation with effects `e`. The computation either
 errors or produces a value of type `a`.
 
 This is moral equivalent of `ErrorT (ContT Unit (Eff e)) a`.
@@ -19,7 +19,7 @@ This is moral equivalent of `ErrorT (ContT Unit (Eff e)) a`.
 type PureAff a = forall e. Aff e a
 ```
 
-A pure asynchronous computation, having no effects other than 
+A pure asynchronous computation, having no effects other than
 asynchronous computation.
 
 #### `Canceler`
@@ -29,10 +29,10 @@ newtype Canceler e
   = Canceler (Error -> Aff e Boolean)
 ```
 
-A canceler is asynchronous function that can be used to attempt the 
+A canceler is asynchronous function that can be used to attempt the
 cancelation of a computation. Returns a boolean flag indicating whether
 or not the cancellation was successful. Many computations may be composite,
-in such cases the flag indicates whether any part of the computation was 
+in such cases the flag indicates whether any part of the computation was
 successfully canceled. The flag should not be used for communication.
 
 #### `cancel`
@@ -50,7 +50,7 @@ cancelWith :: forall e a. Aff e a -> Canceler e -> Aff e a
 ```
 
 This function allows you to attach a custom canceler to an asynchronous
-computation. If the computation is canceled, then the custom canceler 
+computation. If the computation is canceled, then the custom canceler
 will be run along side the computation's own canceler.
 
 #### `launchAff`
@@ -105,7 +105,7 @@ Runs the asynchronous computation off the current execution context.
 later' :: forall e a. Number -> Aff e a -> Aff e a
 ```
 
-Runs the specified asynchronous computation later, by the specified 
+Runs the specified asynchronous computation later, by the specified
 number of milliseconds.
 
 #### `forkAff`
@@ -117,7 +117,7 @@ forkAff :: forall e a. Aff e a -> Aff e (Canceler e)
 Forks the specified asynchronous computation so subsequent computations
 will not block on the result of the computation.
 
-Returns a canceler that can be used to attempt cancellation of the 
+Returns a canceler that can be used to attempt cancellation of the
 forked computation.
 
 #### `attempt`

--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -33,20 +33,20 @@ module Control.Monad.Aff
   import Control.Monad.Eff.Class
   import Control.Monad.Error.Class(MonadError, throwError)
 
-  -- | An asynchronous computation with effects `e`. The computation either 
+  -- | An asynchronous computation with effects `e`. The computation either
   -- | errors or produces a value of type `a`.
   -- |
   -- | This is moral equivalent of `ErrorT (ContT Unit (Eff e)) a`.
   foreign import data Aff :: # ! -> * -> *
 
-  -- | A pure asynchronous computation, having no effects other than 
+  -- | A pure asynchronous computation, having no effects other than
   -- | asynchronous computation.
   type PureAff a = forall e. Aff e a
 
-  -- | A canceler is asynchronous function that can be used to attempt the 
+  -- | A canceler is asynchronous function that can be used to attempt the
   -- | cancelation of a computation. Returns a boolean flag indicating whether
   -- | or not the cancellation was successful. Many computations may be composite,
-  -- | in such cases the flag indicates whether any part of the computation was 
+  -- | in such cases the flag indicates whether any part of the computation was
   -- | successfully canceled. The flag should not be used for communication.
   newtype Canceler e = Canceler (Error -> Aff e Boolean)
 
@@ -55,7 +55,7 @@ module Control.Monad.Aff
   cancel (Canceler f) = f
 
   -- | This function allows you to attach a custom canceler to an asynchronous
-  -- | computation. If the computation is canceled, then the custom canceler 
+  -- | computation. If the computation is canceled, then the custom canceler
   -- | will be run along side the computation's own canceler.
   cancelWith :: forall e a. Aff e a -> Canceler e -> Aff e a
   cancelWith aff c = runFn3 _cancelWith nonCanceler aff c
@@ -86,7 +86,7 @@ module Control.Monad.Aff
   later :: forall e a. Aff e a -> Aff e a
   later = later' 0
 
-  -- | Runs the specified asynchronous computation later, by the specified 
+  -- | Runs the specified asynchronous computation later, by the specified
   -- | number of milliseconds.
   later' :: forall e a. Number -> Aff e a -> Aff e a
   later' n aff = runFn3 _setTimeout nonCanceler n aff
@@ -101,7 +101,7 @@ module Control.Monad.Aff
   -- | Forks the specified asynchronous computation so subsequent computations
   -- | will not block on the result of the computation.
   -- |
-  -- | Returns a canceler that can be used to attempt cancellation of the 
+  -- | Returns a canceler that can be used to attempt cancellation of the
   -- | forked computation.
   forkAff :: forall e a. Aff e a -> Aff e (Canceler e)
   forkAff aff = runFn2 _forkAff nonCanceler aff
@@ -205,7 +205,7 @@ module Control.Monad.Aff
             };
 
             canceler2(e)(s, f);
-            canceler1(e)(s, f);            
+            canceler1(e)(s, f);
 
             return nonCanceler;
           };


### PR DESCRIPTION
Fixes #21. I used the conservative implementation, choosing to only use `setImmediate` when `millis` is zero or lower. I figure that a value of `1` is much closer to `4` than it is to `0` given a sufficiently fast computer.