### PR TITLE
Stop ignoring exceptions in `launchAff`

### DIFF
--- a/docs/Control.Monad.Aff.md
+++ b/docs/Control.Monad.Aff.md
@@ -86,9 +86,8 @@ Converts the asynchronous computation into a synchronous one. All values
 are ignored, and if the computation produces an error, it is thrown.
 
 Catching exceptions by using `catchException` with the resulting Eff
-computation is not recommended, as exceptions may end up being thrown in
-a different thread, due to the asynchronous nature of Aff. In such a
-case, the exception cannot be caught.
+computation is not recommended, as exceptions may end up being thrown
+asynchronously, in which case they cannot be caught.
 
 If you do need to handle exceptions, you can use `runAff` instead, or
 you can handle the exception within the Aff computation, using

--- a/docs/Control.Monad.Aff.md
+++ b/docs/Control.Monad.Aff.md
@@ -85,6 +85,15 @@ launchAff :: forall e a. Aff e a -> Eff (err :: EXCEPTION | e) Unit
 Converts the asynchronous computation into a synchronous one. All values
 are ignored, and if the computation produces an error, it is thrown.
 
+Catching exceptions by using `catchException` with the resulting Eff
+computation is not recommended, as exceptions may end up being thrown in
+a different thread, due to the asynchronous nature of Aff. In such a
+case, the exception cannot be caught.
+
+If you do need to handle exceptions, you can use `runAff` instead, or
+you can handle the exception within the Aff computation, using
+`catchError` (or any of the other mechanisms).
+
 #### `runAff`
 
 ``` purescript

--- a/docs/Control.Monad.Aff.md
+++ b/docs/Control.Monad.Aff.md
@@ -79,11 +79,11 @@ will be run along side the computation's own canceler.
 #### `launchAff`
 
 ``` purescript
-launchAff :: forall e a. Aff e a -> Eff e Unit
+launchAff :: forall e a. Aff e a -> Eff (err :: EXCEPTION | e) Unit
 ```
 
 Converts the asynchronous computation into a synchronous one. All values
-and errors are ignored.
+are ignored, and if the computation produces an error, it is thrown.
 
 #### `runAff`
 

--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -68,9 +68,8 @@ module Control.Monad.Aff
   -- | are ignored, and if the computation produces an error, it is thrown.
   -- |
   -- | Catching exceptions by using `catchException` with the resulting Eff
-  -- | computation is not recommended, as exceptions may end up being thrown in
-  -- | a different thread, due to the asynchronous nature of Aff. In such a
-  -- | case, the exception cannot be caught.
+  -- | computation is not recommended, as exceptions may end up being thrown
+  -- | asynchronously, in which case they cannot be caught.
   -- |
   -- | If you do need to handle exceptions, you can use `runAff` instead, or
   -- | you can handle the exception within the Aff computation, using

--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -66,6 +66,15 @@ module Control.Monad.Aff
 
   -- | Converts the asynchronous computation into a synchronous one. All values
   -- | are ignored, and if the computation produces an error, it is thrown.
+  -- |
+  -- | Catching exceptions by using `catchException` with the resulting Eff
+  -- | computation is not recommended, as exceptions may end up being thrown in
+  -- | a different thread, due to the asynchronous nature of Aff. In such a
+  -- | case, the exception cannot be caught.
+  -- |
+  -- | If you do need to handle exceptions, you can use `runAff` instead, or
+  -- | you can handle the exception within the Aff computation, using
+  -- | `catchError` (or any of the other mechanisms).
   launchAff :: forall e a. Aff e a -> Eff (err :: EXCEPTION | e) Unit
   launchAff = runAff throwException (const (pure unit)) <<< liftEx
     where


### PR DESCRIPTION
`launchAff` will now throw exceptions rather than swallowing them. Fixes
issue #32