### PR TITLE
Fix link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ main = launchAff $
      liftEff $ log response.body
 ```
 
-See the [examples directory](/examples/src/Examples.purs) for more examples.
+See the [examples directory](https://github.com/slamdata/purescript-aff/blob/master/examples/src/Examples.purs) for more examples.
 
 # Getting Started
 


### PR DESCRIPTION
not sure if this is what you want, but it should make the link work under http://pursuit.purescript.org/packages/purescript-aff/0.11.0