### PR TITLE
Change type of log and print to return Unit

### DIFF
--- a/examples/src/Examples.purs
+++ b/examples/src/Examples.purs
@@ -1,168 +1,169 @@
 module Examples where
-  import Control.Monad.Eff.Console (CONSOLE())
 
-  import Data.Either(either)
+import Prelude
 
-  import Prelude
-  import Control.Monad.Aff
-  import Control.Monad.Aff.AVar
-  import Control.Monad.Aff.Par
-  import Control.Monad.Aff.Console(print)
-  import Control.Apply((*>))
-  import Control.Alt(Alt, (<|>))
-  import Control.Monad.Eff.Class(liftEff)
-  import Control.Monad.Eff.Exception(error)
-  import Control.Monad.Error.Class(throwError)
+import Control.Monad.Aff
+import Control.Monad.Aff.AVar
+import Control.Monad.Aff.Par
+import Control.Monad.Aff.Console (print)
+import Control.Apply ((*>))
+import Control.Alt (Alt, (<|>))
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Console (CONSOLE())
+import Control.Monad.Eff.Exception (EXCEPTION(), error)
+import Control.Monad.Error.Class (throwError)
+import Data.Either (either)
 
-  type Test a = forall e. Aff (console :: CONSOLE | e) a
-  type TestAVar a = forall e. Aff (console :: CONSOLE, avar :: AVAR | e) a
+type Test a = forall e. Aff (console :: CONSOLE | e) a
+type TestAVar a = forall e. Aff (console :: CONSOLE, avar :: AVAR | e) a
 
-  test_sequencing :: Int -> Test String
-  test_sequencing 0 = print "Done"
-  test_sequencing n = do
-    later' 100 (print (show (n / 10) ++ " seconds left"))
-    test_sequencing (n - 1)
+test_sequencing :: Int -> Test Unit
+test_sequencing 0 = print "Done"
+test_sequencing n = do
+  later' 100 (print (show (n / 10) ++ " seconds left"))
+  test_sequencing (n - 1)
 
-  test_pure :: Test String
-  test_pure = do
-    pure unit
-    pure unit
-    pure unit
-    print "Success: Got all the way past 4 pures"
+test_pure :: Test Unit
+test_pure = do
+  pure unit
+  pure unit
+  pure unit
+  print "Success: Got all the way past 4 pures"
 
-  test_attempt :: Test String
-  test_attempt = do
-    e <- attempt (throwError (error "Oh noes!"))
-    either (const $ print "Success: Exception caught") (const $ print "Failure: Exception NOT caught!!!") e
+test_attempt :: Test Unit
+test_attempt = do
+  e <- attempt (throwError (error "Oh noes!"))
+  either (const $ print "Success: Exception caught") (const $ print "Failure: Exception NOT caught!!!") e
 
-  test_apathize :: Test String
-  test_apathize = do
-    apathize $ throwError (error "Oh noes!")
-    print "Success: Exceptions don't stop the apathetic"
+test_apathize :: Test Unit
+test_apathize = do
+  apathize $ throwError (error "Oh noes!")
+  print "Success: Exceptions don't stop the apathetic"
 
-  test_putTakeVar :: TestAVar String
-  test_putTakeVar = do
-    v <- makeVar
-    forkAff (later $ putVar v 1.0)
-    a <- takeVar v
-    print ("Success: Value " ++ show a)
+test_putTakeVar :: TestAVar Unit
+test_putTakeVar = do
+  v <- makeVar
+  forkAff (later $ putVar v 1.0)
+  a <- takeVar v
+  print ("Success: Value " ++ show a)
 
-  test_killFirstForked :: Test String
-  test_killFirstForked = do
-    c <- forkAff (later' 100 $ pure "Failure: This should have been killed!")
-    b <- c `cancel` (error "Just die")
-    print (if b then "Success: Killed first forked" else "Failure: Couldn't kill first forked")
+test_killFirstForked :: Test Unit
+test_killFirstForked = do
+  c <- forkAff (later' 100 $ pure "Failure: This should have been killed!")
+  b <- c `cancel` (error "Just die")
+  print (if b then "Success: Killed first forked" else "Failure: Couldn't kill first forked")
 
 
-  test_killVar :: TestAVar String
-  test_killVar = do
-    v <- makeVar
-    killVar v (error "DOA")
-    e <- attempt $ takeVar v
-    either (const $ print "Success: Killed queue dead") (const $ print "Failure: Oh noes, queue survived!") e
+test_killVar :: TestAVar Unit
+test_killVar = do
+  v <- makeVar
+  killVar v (error "DOA")
+  e <- attempt $ takeVar v
+  either (const $ print "Success: Killed queue dead") (const $ print "Failure: Oh noes, queue survived!") e
 
-  test_finally :: TestAVar String
-  test_finally = do
-    v <- makeVar
-    finally
-      (putVar v 0)
-      (putVar v 2)
-    apathize $ finally
-      (throwError (error "poof!") *> putVar v 666) -- this putVar should not get executed
-      (putVar v 40)
-    n1 <- takeVar v
-    n2 <- takeVar v
-    n3 <- takeVar v
-    print $ if n1 + n2 + n3 == 42 then "Success: effects amount to 42."
-                                  else "Failure: Expected 42."
+test_finally :: TestAVar Unit
+test_finally = do
+  v <- makeVar
+  finally
+    (putVar v 0)
+    (putVar v 2)
+  apathize $ finally
+    (throwError (error "poof!") *> putVar v 666) -- this putVar should not get executed
+    (putVar v 40)
+  n1 <- takeVar v
+  n2 <- takeVar v
+  n3 <- takeVar v
+  print $ if n1 + n2 + n3 == 42 then "Success: effects amount to 42."
+                                else "Failure: Expected 42."
 
-  test_parRace :: TestAVar String
-  test_parRace = do
-    s <- runPar (Par (later' 100 $ pure "Success: Early bird got the worm") <|>
-                 Par (later' 200 $ pure "Failure: Late bird got the worm"))
-    print s
+test_parRace :: TestAVar Unit
+test_parRace = do
+  s <- runPar (Par (later' 100 $ pure "Success: Early bird got the worm") <|>
+               Par (later' 200 $ pure "Failure: Late bird got the worm"))
+  print s
 
-  test_parRaceKill1 :: TestAVar String
-  test_parRaceKill1 = do
-    s <- runPar (Par (later' 100 $ throwError (error ("Oh noes!"))) <|>
-                 Par (later' 200 $ pure "Success: Early error was ignored in favor of late success"))
-    print s
+test_parRaceKill1 :: TestAVar Unit
+test_parRaceKill1 = do
+  s <- runPar (Par (later' 100 $ throwError (error ("Oh noes!"))) <|>
+               Par (later' 200 $ pure "Success: Early error was ignored in favor of late success"))
+  print s
 
-  test_parRaceKill2 :: TestAVar String
-  test_parRaceKill2 = do
-    e <- attempt $ runPar (Par (later' 100 $ throwError (error ("Oh noes!"))) <|>
-                           Par (later' 200 $ throwError (error ("Oh noes!"))))
-    either (const $ print "Success: Killing both kills it dead") (const $ print "Failure: It's alive!!!") e
+test_parRaceKill2 :: TestAVar Unit
+test_parRaceKill2 = do
+  e <- attempt $ runPar (Par (later' 100 $ throwError (error ("Oh noes!"))) <|>
+                         Par (later' 200 $ throwError (error ("Oh noes!"))))
+  either (const $ print "Success: Killing both kills it dead") (const $ print "Failure: It's alive!!!") e
 
-  test_semigroupCanceler :: Test String
-  test_semigroupCanceler =
-    let
-      c = Canceler (const (pure true)) <> Canceler (const (pure true))
-    in do
-      v <- cancel c (error "CANCEL")
-      print (if v then "Success: Canceled semigroup composite canceler"
-                       else "Failure: Could not cancel semigroup composite canceler")
+test_semigroupCanceler :: Test Unit
+test_semigroupCanceler =
+  let
+    c = Canceler (const (pure true)) <> Canceler (const (pure true))
+  in do
+    v <- cancel c (error "CANCEL")
+    print (if v then "Success: Canceled semigroup composite canceler"
+                     else "Failure: Could not cancel semigroup composite canceler")
 
-  test_cancelLater :: TestAVar String
-  test_cancelLater = do
-    c <- forkAff $ (do pure "Binding"
-                       _ <- later' 100 $ print ("Failure: Later was not canceled!")
-                       pure "Binding")
-    v <- cancel c (error "Cause")
-    print (if v then "Success: Canceled later" else "Failure: Did not cancel later")
+test_cancelLater :: TestAVar Unit
+test_cancelLater = do
+  c <- forkAff $ (do pure "Binding"
+                     _ <- later' 100 $ print ("Failure: Later was not canceled!")
+                     pure "Binding")
+  v <- cancel c (error "Cause")
+  print (if v then "Success: Canceled later" else "Failure: Did not cancel later")
 
-  test_cancelPar :: TestAVar String
-  test_cancelPar = do
-    c  <- forkAff <<< runPar $ Par (later' 100 $ print "Failure: #1 should not get through") <|>
-                               Par (later' 100 $ print "Failure: #2 should not get through")
-    v  <- c `cancel` (error "Must cancel")
-    print (if v then "Success: Canceling composite of two Par succeeded"
-                     else "Failure: Canceling composite of two Par failed")
+test_cancelPar :: TestAVar Unit
+test_cancelPar = do
+  c  <- forkAff <<< runPar $ Par (later' 100 $ print "Failure: #1 should not get through") <|>
+                             Par (later' 100 $ print "Failure: #2 should not get through")
+  v  <- c `cancel` (error "Must cancel")
+  print (if v then "Success: Canceling composite of two Par succeeded"
+                   else "Failure: Canceling composite of two Par failed")
 
-  main = launchAff $ do
-    print "Testing sequencing"
-    test_sequencing 3
+main :: forall eff . Eff ( avar :: AVAR, console :: CONSOLE, err :: EXCEPTION | eff ) Unit
+main = launchAff $ do
+  print "Testing sequencing"
+  test_sequencing 3
 
-    print "Testing pure"
-    test_pure
+  print "Testing pure"
+  test_pure
 
-    print "Testing attempt"
-    test_attempt
+  print "Testing attempt"
+  test_attempt
 
-    print "Testing later"
-    later $ print "Success: It happened later"
+  print "Testing later"
+  later $ print "Success: It happened later"
 
-    print "Testing kill of later"
-    test_cancelLater
+  print "Testing kill of later"
+  test_cancelLater
 
-    print "Testing kill of first forked"
-    test_killFirstForked
+  print "Testing kill of first forked"
+  test_killFirstForked
 
-    print "Testing apathize"
-    test_apathize
+  print "Testing apathize"
+  test_apathize
 
-    print "Testing semigroup canceler"
-    test_semigroupCanceler
+  print "Testing semigroup canceler"
+  test_semigroupCanceler
 
-    print "Testing AVar - putVar, takeVar"
-    test_putTakeVar
+  print "Testing AVar - putVar, takeVar"
+  test_putTakeVar
 
-    print "Testing AVar killVar"
-    test_killVar
+  print "Testing AVar killVar"
+  test_killVar
 
-    print "Testing finally"
-    test_finally
+  print "Testing finally"
+  test_finally
 
-    print "Testing Par (<|>)"
-    test_parRace
+  print "Testing Par (<|>)"
+  test_parRace
 
-    print "Testing Par (<|>) - kill one"
-    test_parRaceKill1
+  print "Testing Par (<|>) - kill one"
+  test_parRaceKill1
 
-    print "Testing Par (<|>) - kill two"
-    test_parRaceKill2
+  print "Testing Par (<|>) - kill two"
+  test_parRaceKill2
 
-    print "Testing cancel of Par (<|>)"
-    test_cancelPar
+  print "Testing cancel of Par (<|>)"
+  test_cancelPar
 
-    print "Done testing"
+  print "Done testing"

--- a/src/Control/Monad/Aff/Console.purs
+++ b/src/Control/Monad/Aff/Console.purs
@@ -8,14 +8,10 @@ import Control.Monad.Eff.Class (liftEff)
 
 -- | Logs any string to the console. This basically saves you
 -- | from writing `liftEff $ log x` everywhere.
-log :: forall e. String -> Aff (console :: C.CONSOLE | e) String
-log s = do
-  liftEff $ C.log s
-  return s
+log :: forall e. String -> Aff (console :: C.CONSOLE | e) Unit
+log = liftEff <<< C.log
 
 -- | Prints any `Show`-able value to the console. This basically saves you
 -- | from writing `liftEff $ print x` everywhere.
-print :: forall e a. (Show a) => a -> Aff (console :: C.CONSOLE | e) a
-print a = do
-  liftEff $ C.print a
-  return a
+print :: forall e a. (Show a) => a -> Aff (console :: C.CONSOLE | e) Unit
+print = liftEff <<< C.print


### PR DESCRIPTION
This pull request changes the type of `log` and `print` to return `Unit` instead of `String` and `a` respectively.

This closes issue #41.

This pull request also contains two commits to clean up the compiler warnings and indentation in the Examples.purs file.