### PR TITLE
Removing shadowing in catch blocks.

### DIFF
--- a/src/Control/Monad/Aff.js
+++ b/src/Control/Monad/Aff.js
@@ -20,8 +20,8 @@ exports._cancelWith = function (nonCanceler, aff, canceler1) {
           if (cancellations === 2 && !errored) {
             try {
               success(result);
-            } catch (e) {
-              error(e);
+            } catch (err) {
+              error(err);
             }
           }
         };
@@ -65,8 +65,8 @@ exports._setTimeout = function (nonCanceler, millis, aff) {
 
           try {
             s(true);
-          } catch (e) {
-            f(e);
+          } catch (err) {
+            f(err);
           }
 
           return nonCanceler;
@@ -88,8 +88,8 @@ exports._forkAff = function (nonCanceler, aff) {
 
     try {
       success(canceler);
-    } catch (e) {
-      error(e);
+    } catch (err) {
+      error(err);
     }
 
     return nonCanceler;
@@ -120,8 +120,8 @@ exports._forkAll = function (nonCanceler, foldl, affs) {
           if (cancellations === cancelers.length && !errored) {
             try {
               success(result);
-            } catch (e) {
-              error(e);
+            } catch (err) {
+              error(err);
             }
           }
         };
@@ -143,8 +143,8 @@ exports._forkAll = function (nonCanceler, foldl, affs) {
 
     try {
       success(canceler);
-    } catch(e) {
-      error(e);
+    } catch (err) {
+      error(err);
     }
 
     return nonCanceler;
@@ -161,8 +161,8 @@ exports._makeAff = function (cb) {
       return function() {
         try {
           success(v);
-        } catch (e) {
-          error(e);
+        } catch (err) {
+          error(err);
         }
       };
     })();
@@ -173,8 +173,8 @@ exports._pure = function (nonCanceler, v) {
   return function(success, error) {
     try {
       success(v);
-    } catch (e) {
-      error(e);
+    } catch (err) {
+      error(err);
     }
 
     return nonCanceler;
@@ -194,8 +194,8 @@ exports._fmap = function (f, aff) {
     return aff(function(v) {
       try {
         success(f(v));
-      } catch (e) {
-        error(e);
+      } catch (err) {
+        error(err);
       }
     }, error);
   };
@@ -235,8 +235,8 @@ exports._bind = function (alwaysCanceler, aff, f) {
             if (bool || isCanceled) {
               try {
                 s(true);
-              } catch (e) {
-                f(e);
+              } catch (err) {
+                f(err);
               }
             } else {
               onCanceler = function(canceler) {
@@ -255,14 +255,14 @@ exports._attempt = function (Left, Right, aff) {
     return aff(function(v) {
       try {
         success(Right(v));
-      } catch (e) {
-        error(e);
+      } catch (err) {
+        error(err);
       }
     }, function(e) {
       try {
         success(Left(e));
-      } catch (e) {
-        error(e);
+      } catch (err) {
+        error(err);
       }
     });
   };
@@ -273,8 +273,8 @@ exports._runAff = function (errorT, successT, aff) {
     return aff(function(v) {
       try {
         successT(v)();
-      } catch (e) {
-        errorT(e)();
+      } catch (err) {
+        errorT(err)();
       }
     }, function(e) {
       errorT(e)();
@@ -286,8 +286,8 @@ exports._liftEff = function (nonCanceler, e) {
   return function(success, error) {
     try {
       success(e());
-    } catch (e) {
-      error(e);
+    } catch (err) {
+      error(err);
     }
 
     return nonCanceler;

--- a/src/Control/Monad/Aff/AVar.js
+++ b/src/Control/Monad/Aff/AVar.js
@@ -9,10 +9,10 @@ exports._makeVar = function (nonCanceler) {
       success({
         consumers: [],
         producers: [],
-        error: undefined 
+        error: undefined
       });
-    } catch (e) {
-      error(e);
+    } catch (err) {
+      error(err);
     }
 
     return nonCanceler;
@@ -32,7 +32,7 @@ exports._takeVar = function (nonCanceler, avar) {
     }
 
     return nonCanceler;
-  } 
+  }
 }
 
 exports._putVar = function (nonCanceler, avar, a) {
@@ -43,8 +43,8 @@ exports._putVar = function (nonCanceler, avar, a) {
       avar.producers.push(function(success, error) {
         try {
           success(a);
-        } catch (e) {
-          error(e);
+        } catch (err) {
+          error(err);
         }
       });
 
@@ -54,10 +54,10 @@ exports._putVar = function (nonCanceler, avar, a) {
 
       try {
         consumer.success(a);
-      } catch (e) {
-        error(e);
+      } catch (err) {
+        error(err);
 
-        return;                  
+        return;
       }
 
       success({});
@@ -81,8 +81,8 @@ exports._killVar = function (nonCanceler, avar, e) {
 
         try {
           consumer.error(e);
-        } catch (e) {
-          errors.push(e);              
+        } catch (err) {
+          errors.push(err);
         }
       }
 


### PR DESCRIPTION
The current codebase uses `e` as the standard name given to exceptions caught by `catch` blocks. In many cases this shadows an existing `e` in scope. This is fine in most scenarios, but it trips up some minification and uglification processes (see for instance https://github.com/mishoo/UglifyJS2/issues/409#issuecomment-149593800). Since it does no harm to rename such variables to avoid the shadowing in the first place, this PR performs such a renaming to (hopefully) enable more minification tools to work properly without changing the library's semantics.