### PR TITLE
Affable, take two

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "purescript-console": "^0.1.0",
     "purescript-exceptions": "^0.3.0",
-    "purescript-free": "^0.9.1",
     "purescript-functions": "^0.1.0",
     "purescript-transformers": "^0.8.1"
   }

--- a/src/Control/Monad/Aff/Class.purs
+++ b/src/Control/Monad/Aff/Class.purs
@@ -4,8 +4,8 @@ import Prelude
 
 import Control.Monad.Aff (Aff())
 import Control.Monad.Cont.Trans (ContT())
+import Control.Monad.Eff.Class (MonadEff)
 import Control.Monad.Except.Trans (ExceptT())
-import Control.Monad.Free (Free(), liftF)
 import Control.Monad.List.Trans (ListT())
 import Control.Monad.Maybe.Trans (MaybeT())
 import Control.Monad.Reader.Trans (ReaderT())
@@ -16,50 +16,32 @@ import Control.Monad.Writer.Trans (WriterT())
 
 import Data.Monoid (Monoid)
 
--- | A class for types that can carry an `Aff` value by some means.
-class Affable e m where
-  liftAff :: forall a. Aff e a -> m a
+class (MonadEff eff m) <= MonadAff eff m where
+  liftAff :: forall a. Aff eff a -> m a
 
-instance affableAff :: Affable e (Aff e) where
+instance monadAffAff :: MonadAff e (Aff e) where
   liftAff = id
 
-instance affableFree :: (Affable eff f) => Affable eff (Free f) where
-  liftAff = liftF <<< liftAff
-
-instance affableContT :: (Monad m, Affable eff m) => Affable eff (ContT r m) where
+instance monadAffContT :: (MonadAff eff m) => MonadAff eff (ContT r m) where
   liftAff = lift <<< liftAff
 
-instance affableExceptT :: (Monad m, Affable eff m) => Affable eff (ExceptT e m) where
+instance monadAffExceptT :: (MonadAff eff m) => MonadAff eff (ExceptT e m) where
   liftAff = lift <<< liftAff
 
-instance affableListT :: (Monad m, Affable eff m) => Affable eff (ListT m) where
+instance monadAffListT :: (MonadAff eff m) => MonadAff eff (ListT m) where
   liftAff = lift <<< liftAff
 
-instance affableMaybe :: (Monad m, Affable eff m) => Affable eff (MaybeT m) where
+instance monadAffMaybe :: (MonadAff eff m) => MonadAff eff (MaybeT m) where
   liftAff = lift <<< liftAff
 
-instance affableReader :: (Monad m, Affable eff m) => Affable eff (ReaderT r m) where
+instance monadAffReader :: (MonadAff eff m) => MonadAff eff (ReaderT r m) where
   liftAff = lift <<< liftAff
 
-instance affableRWS :: (Monad m, Monoid w, Affable eff m) => Affable eff (RWST r w s m) where
+instance monadAffRWS :: (MonadAff eff m, Monoid w) => MonadAff eff (RWST r w s m) where
   liftAff = lift <<< liftAff
 
-instance affableState :: (Monad m, Affable eff m) => Affable eff (StateT s m) where
+instance monadAffState :: (MonadAff eff m) => MonadAff eff (StateT s m) where
   liftAff = lift <<< liftAff
 
-instance affableWriter :: (Monad m, Monoid w, Affable eff m) => Affable eff (WriterT w m) where
+instance monadAffWriter :: (MonadAff eff m, Monoid w) => MonadAff eff (WriterT w m) where
   liftAff = lift <<< liftAff
-
---| A class for types where the `Affable` instance for a `Monad` is also a monad
---| morphism.
-class (Monad m, Affable e m) <= MonadAff e m
-
-instance monadAffAff :: MonadAff e (Aff e)
-instance monadAffContT :: (Monad m, Affable eff m) => MonadAff eff (ContT r m)
-instance monadAffExceptT :: (Monad m, Affable eff m) => MonadAff eff (ExceptT e m)
-instance monadAffListT :: (Monad m, Affable eff m) => MonadAff eff (ListT m)
-instance monadAffMaybe :: (Monad m, Affable eff m) => MonadAff eff (MaybeT m)
-instance monadAffReader :: (Monad m, Affable eff m) => MonadAff eff (ReaderT r m)
-instance monadAffRWS :: (Monad m, Monoid w, Affable eff m) => MonadAff eff (RWST r w s m)
-instance monadAffState :: (Monad m, Affable eff m) => MonadAff eff (StateT s m)
-instance monadAffWriter :: (Monad m, Monoid w, Affable eff m) => MonadAff eff (WriterT w m)


### PR DESCRIPTION
- `Affable` is now separate from `MonadAff`
- There's an `instance affableMonadAff :: (MonadAff eff m) => Affable eff m`. I'm not sure how useful it will be currently, it might need fundeps to behave well without use of type annotations
- I added `MonadEff` as a superclass of `MonadAff` - I think that should always have been the case if we're saying `Aff` is the moral equivalent of `ErrorT (ContT Unit (Eff e) a`?