### PR TITLE
Allow cancellation of computations forked with `runAff`

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -5,13 +5,14 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Apply ((*>))
 import Control.Parallel.Class (parallel, runParallel)
-import Control.Monad.Aff (Aff, runAff, makeAff, later, later', forkAff, forkAll, Canceler(..), cancel, attempt, finally, apathize)
+import Control.Monad.Aff (Aff, runAff, makeAff, launchAff, later, later', forkAff, forkAll, Canceler(..), cancel, attempt, finally, apathize)
 import Control.Monad.Aff.AVar (AVAR, makeVar, makeVar', putVar, modifyVar, takeVar, killVar)
 import Control.Monad.Aff.Console (log)
 import Control.Monad.Cont.Class (callCC)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
-import Control.Monad.Eff.Exception (EXCEPTION, throwException, error, message)
+import Control.Monad.Eff.Console (log) as Eff
+import Control.Monad.Eff.Exception (EXCEPTION, throwException, error, message, try)
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Rec.Class (tailRecM)
 import Data.Either (Either(..), either, fromLeft, fromRight)
@@ -137,6 +138,18 @@ test_cancelLater = do
   v <- cancel c (error "Cause")
   log (if v then "Success: Canceled later" else "Failure: Did not cancel later")
 
+test_cancelLaunchLater :: forall e. Eff (console :: CONSOLE, err :: EXCEPTION | e) Unit
+test_cancelLaunchLater = do
+  c <- launchAff $ later' 100 $ log ("Failure: Later was not canceled!")
+  void $ launchAff $ (do v <- cancel c (error "Cause")
+                         log (if v then "Success: Canceled later" else "Failure: Did not cancel later"))
+
+test_cancelRunLater :: forall e. Eff (console :: CONSOLE | e) Unit
+test_cancelRunLater = do
+  c <- runAff (const (pure unit)) (const (pure unit)) $ later' 100 $ log ("Failure: Later was not canceled!")
+  void $ try $ launchAff $ (do v <- cancel c (error "Cause")
+                               log (if v then "Success: Canceled later" else "Failure: Did not cancel later"))
+
 test_cancelParallel :: TestAVar Unit
 test_cancelParallel = do
   c  <- forkAff <<< runParallel $ parallel (later' 100 $ log "Failure: #1 should not get through") <|>
@@ -187,69 +200,76 @@ delay n = callCC \cont ->
   later' n (cont unit)
 
 main :: Eff (console :: CONSOLE, avar :: AVAR, err :: EXCEPTION) Unit
-main = runAff throwException (const (pure unit)) $ do
-  log "Testing sequencing"
-  test_sequencing 3
+main = do
+  Eff.log "Testing kill of later launched in separate Aff"
+  test_cancelLaunchLater
 
-  log "Testing pure"
-  test_pure
+  Eff.log "Testing kill of later run in separate Aff"
+  test_cancelRunLater
 
-  log "Testing makeAff"
-  test_makeAff
+  void $ runAff throwException (const (pure unit)) $ do
+    log "Testing sequencing"
+    test_sequencing 3
 
-  log "Testing attempt"
-  test_attempt
+    log "Testing pure"
+    test_pure
 
-  log "Testing later"
-  later $ log "Success: It happened later"
+    log "Testing makeAff"
+    test_makeAff
 
-  log "Testing kill of later"
-  test_cancelLater
+    log "Testing attempt"
+    test_attempt
 
-  log "Testing kill of first forked"
-  test_killFirstForked
+    log "Testing later"
+    later $ log "Success: It happened later"
 
-  log "Testing apathize"
-  test_apathize
+    log "Testing kill of later"
+    test_cancelLater
 
-  log "Testing semigroup canceler"
-  test_semigroupCanceler
+    log "Testing kill of first forked"
+    test_killFirstForked
 
-  log "Testing AVar - putVar, takeVar"
-  test_putTakeVar
+    log "Testing apathize"
+    test_apathize
 
-  log "Testing AVar killVar"
-  test_killVar
+    log "Testing semigroup canceler"
+    test_semigroupCanceler
 
-  log "Testing finally"
-  test_finally
+    log "Testing AVar - putVar, takeVar"
+    test_putTakeVar
 
-  log "Test Parallel (*>)"
-  test_parError
+    log "Testing AVar killVar"
+    test_killVar
 
-  log "Testing Parallel (<|>)"
-  test_parRace
+    log "Testing finally"
+    test_finally
 
-  log "Testing Parallel (<|>) - kill one"
-  test_parRaceKill1
+    log "Test Parallel (*>)"
+    test_parError
 
-  log "Testing Parallel (<|>) - kill two"
-  test_parRaceKill2
+    log "Testing Parallel (<|>)"
+    test_parRace
 
-  log "Testing cancel of Parallel (<|>)"
-  test_cancelParallel
+    log "Testing Parallel (<|>) - kill one"
+    test_parRaceKill1
 
-  log "Testing synchronous tailRecM"
-  test_syncTailRecM
+    log "Testing Parallel (<|>) - kill two"
+    test_parRaceKill2
 
-  log "pre-delay"
-  delay 1000
-  log "post-delay"
+    log "Testing cancel of Parallel (<|>)"
+    test_cancelParallel
 
-  loopAndBounce 1000000
+    log "Testing synchronous tailRecM"
+    test_syncTailRecM
 
-  all 100000
+    log "pre-delay"
+    delay 1000
+    log "post-delay"
 
-  cancelAll 100000
+    loopAndBounce 1000000
 
-  log "Done testing"
+    all 100000
+
+    cancelAll 100000
+
+    log "Done testing"


### PR DESCRIPTION
At present, in order to have a cancellable asynchronous computation it seems you forego both success and error callbacks in the call to `forkAff`, the only function to return a `Canceler`.

Particularly given that in the JavaScript `runAff` already returns a `Canceler` I saw no reason not to include a version returning it in PureScript.

In the process of adding a test for the above, I was inconvenienced by the inability to
```
do
  c <- runAff throwException (const (pure unit)) a
  launchAff $ cancel c (error msg)
```
due to the odd coersion of effect records in `launchAff` so I thought I'd propose a change there as well.

I'm assuming that the breaking nature of these changes will be contentious at least but thought I'd start here.