### PR TITLE
Initial pass on catch rewriting; needs review!

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,8 @@
     "purescript-exceptions": "^1.0.0",
     "purescript-functions": "^1.0.0",
     "purescript-transformers": "^1.0.0"
+  },
+  "devDependencies": {
+    "purescript-partial": "^1.1.2"
   }
 }

--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.synchronousUnexpectedThrowError = function() {
+  throw new Error("ok");
+};


### PR DESCRIPTION
I have a feeling many of these hairy JS functions could be moved to PS, so I want to take a pass at that too before this is accepted.  Opening this now to get initial feedback/concerns.  This is definitely a scary change, but there are definitely some issues with the current code.

The gist of the problem is that `success` callback calls shouldn't be wrapped in try/catch because `success` returns to user code.  An Aff/Promise should only ever resolve to 'success' or 'failure'.  Wrapping the success callback in a try/catch makes it possible to resolve with 'success' and then later resolve with 'error', possibly causing user code to re-run.

The second issue is that while `success` _shouldn't_ be caught, calling the Eff callback in `makeAff` _should_ catch errors.  Currently any synchronous exceptions will bypass the Aff error handling and travel up the stack unhandled.

Here is `es6-promise`'s equivalent to `makeAff` which is nearly the exact same code: https://github.com/stefanpenner/es6-promise/blob/master/lib/es6-promise/-internal.js#L233

This brings me to another thought.. it seems Aff should derive heavily from a good Promise implementation, or _maybe even_ just wrap another implementation.  If it wraps native Promises it would require polyfills for some users, but JS people are pretty used to that these days.  This would be awesome for FFI as well, as any FFI function that returns Aff would just need the JS side to return a promise-like thing.