### PR TITLE
updates for 0.9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,9 +17,9 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-exceptions": "^0.3.0",
-    "purescript-functions": "^0.1.0",
-    "purescript-transformers": "^0.8.1"
+    "purescript-console": "^1.0.0",
+    "purescript-exceptions": "^1.0.0",
+    "purescript-functions": "^1.0.0",
+    "purescript-transformers": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "pulp build",
-    "test": "pulp test"
+    "build": "psc \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\"",
+    "test": "psc \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\" \"test/**/*.purs\" && psc-bundle \"output/**/*.js\" --module Test.Main --main Test.Main | node"
   },
   "devDependencies": {
-    "pulp": "^8.1.0",
-    "purescript": "^0.7.6",
+    "purescript": "^0.9.1-rc.1",
     "rimraf": "^2.5.2"
   }
 }

--- a/src/Control/Monad/Aff.js
+++ b/src/Control/Monad/Aff.js
@@ -1,8 +1,6 @@
 /* global exports */
 "use strict";
 
-// module Control.Monad.Aff
-
 exports._cancelWith = function (nonCanceler, aff, canceler1) {
   return function(success, error) {
     var canceler2 = aff(success, error);

--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -21,22 +21,20 @@ module Control.Monad.Aff
   where
 
 import Prelude
-
-import Control.Alt (Alt)
-import Control.Alternative (Alternative)
-import Control.Monad.Cont.Class (MonadCont)
-import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Class (MonadEff)
-import Control.Monad.Eff.Exception (Error(), EXCEPTION(), throwException, error)
-import Control.Monad.Error.Class (MonadError, throwError)
-import Control.Monad.Rec.Class (MonadRec, tailRecM)
-import Control.MonadPlus (MonadPlus)
-import Control.Plus (Plus)
-
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
+import Control.Monad.Cont.Class (class MonadCont)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (class MonadEff)
+import Control.Monad.Eff.Exception (Error, EXCEPTION, throwException, error)
+import Control.Monad.Error.Class (class MonadError, throwError)
+import Control.Monad.Rec.Class (class MonadRec)
+import Control.MonadPlus (class MonadZero, class MonadPlus)
+import Control.Plus (class Plus)
 import Data.Either (Either(..), either, isLeft)
-import Data.Foldable (Foldable, foldl)
-import Data.Function (Fn2(), Fn3(), runFn2, runFn3)
-import Data.Monoid (Monoid, mempty)
+import Data.Foldable (class Foldable, foldl)
+import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
+import Data.Monoid (class Monoid, mempty)
 
 -- | An asynchronous computation with effects `e`. The computation either
 -- | errors or produces a value of type `a`.
@@ -187,6 +185,8 @@ instance plusAff :: Plus (Aff e) where
   empty = throwError $ error "Always fails"
 
 instance alternativeAff :: Alternative (Aff e)
+
+instance monadZero :: MonadZero (Aff e)
 
 instance monadPlusAff :: MonadPlus (Aff e)
 

--- a/src/Control/Monad/Aff/AVar.js
+++ b/src/Control/Monad/Aff/AVar.js
@@ -1,8 +1,6 @@
 /* global exports */
 "use strict";
 
-// module Control.Monad.Aff.AVar
-
 exports._makeVar = function (nonCanceler) {
   return function(success, error) {
     try {
@@ -16,8 +14,8 @@ exports._makeVar = function (nonCanceler) {
     }
 
     return nonCanceler;
-  }
-}
+  };
+};
 
 exports._takeVar = function (nonCanceler, avar) {
   return function(success, error) {
@@ -32,8 +30,8 @@ exports._takeVar = function (nonCanceler, avar) {
     }
 
     return nonCanceler;
-  }
-}
+  };
+};
 
 exports._putVar = function (nonCanceler, avar, a) {
   return function(success, error) {
@@ -64,8 +62,8 @@ exports._putVar = function (nonCanceler, avar, a) {
     }
 
     return nonCanceler;
-  }
-}
+  };
+};
 
 exports._killVar = function (nonCanceler, avar, e) {
   return function(success, error) {
@@ -91,5 +89,5 @@ exports._killVar = function (nonCanceler, avar, e) {
     }
 
     return nonCanceler;
-  }
-}
+  };
+};

--- a/src/Control/Monad/Aff/AVar.purs
+++ b/src/Control/Monad/Aff/AVar.purs
@@ -16,7 +16,7 @@ import Prelude
 import Control.Monad.Aff (Aff(), Canceler(), nonCanceler)
 import Control.Monad.Eff.Exception (Error())
 
-import Data.Function (Fn2(), Fn3(), runFn2, runFn3)
+import Data.Function.Uncurried (Fn2(), Fn3(), runFn2, runFn3)
 
 foreign import data AVAR :: !
 
@@ -33,7 +33,7 @@ makeVar' :: forall e a. a -> AffAVar e (AVar a)
 makeVar' a = do
   v <- makeVar
   putVar v a
-  return v
+  pure v
 
 -- | Takes the next value from the asynchronous avar.
 takeVar :: forall e a. AVar a -> AffAVar e a

--- a/src/Control/Monad/Aff/Class.purs
+++ b/src/Control/Monad/Aff/Class.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad.Aff (Aff())
 import Control.Monad.Cont.Trans (ContT())
-import Control.Monad.Eff.Class (MonadEff)
+import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.Except.Trans (ExceptT())
 import Control.Monad.List.Trans (ListT())
 import Control.Monad.Maybe.Trans (MaybeT())
@@ -14,7 +14,7 @@ import Control.Monad.State.Trans (StateT())
 import Control.Monad.Trans (lift)
 import Control.Monad.Writer.Trans (WriterT())
 
-import Data.Monoid (Monoid)
+import Data.Monoid (class Monoid)
 
 class (MonadEff eff m) <= MonadAff eff m where
   liftAff :: forall a. Aff eff a -> m a

--- a/src/Control/Monad/Aff/Console.purs
+++ b/src/Control/Monad/Aff/Console.purs
@@ -1,7 +1,7 @@
 module Control.Monad.Aff.Console where
 
 import Prelude
-import qualified Control.Monad.Eff.Console as C
+import Control.Monad.Eff.Console as C
 
 import Control.Monad.Aff (Aff())
 import Control.Monad.Eff.Class (liftEff)
@@ -11,7 +11,7 @@ import Control.Monad.Eff.Class (liftEff)
 log :: forall e. String -> Aff (console :: C.CONSOLE | e) Unit
 log = liftEff <<< C.log
 
--- | Prints any `Show`-able value to the console. This basically saves you
--- | from writing `liftEff $ print x` everywhere.
-print :: forall e a. (Show a) => a -> Aff (console :: C.CONSOLE | e) Unit
-print = liftEff <<< C.print
+-- | Logs any `Show`-able value to the console. This basically saves you
+-- | from writing `liftEff $ logShow x` everywhere.
+logShow :: forall e a. (Show a) => a -> Aff (console :: C.CONSOLE | e) Unit
+logShow = liftEff <<< C.logShow

--- a/src/Control/Monad/Aff/Par.purs
+++ b/src/Control/Monad/Aff/Par.purs
@@ -7,16 +7,14 @@ module Control.Monad.Aff.Par
   ) where
 
 import Prelude
-
-import Control.Alt (Alt)
-import Control.Alternative (Alternative)
+import Control.Alt (class Alt)
+import Control.Alternative (class Alternative)
 import Control.Monad.Aff (attempt, cancelWith, forkAff)
-import Control.Monad.Aff.AVar (AffAVar(), AVar(), makeVar, makeVar', takeVar, putVar, killVar)
-import Control.Monad.Eff.Exception (Error())
-import Control.Plus (Plus, empty)
-
-import Data.Either (Either(), either)
-import Data.Monoid (Monoid, mempty)
+import Control.Monad.Aff.AVar (AffAVar, AVar, makeVar, makeVar', takeVar, putVar, killVar)
+import Control.Monad.Eff.Exception (Error)
+import Control.Plus (class Plus, empty)
+import Data.Either (Either, either)
+import Data.Monoid (class Monoid, mempty)
 
 newtype Par e a = Par (AffAVar e a)
 
@@ -51,7 +49,7 @@ instance altPar :: Alt (Par e) where
   alt (Par a1) (Par a2) =
     let maybeKill va ve err = do
          e <- takeVar ve
-         if e == 1 then killVar va err else return unit
+         if e == 1 then killVar va err else pure unit
          putVar ve (e + 1)
     in Par do
       va <- makeVar     -- the `a` value

--- a/src/Control/Monad/Aff/Unsafe.js
+++ b/src/Control/Monad/Aff/Unsafe.js
@@ -1,8 +1,6 @@
 /* global exports */
 "use strict";
 
-// module Control.Monad.Aff.Unsafe
-
 exports.unsafeTrace = function (v) {
   return function(success, error) {
     console.log(v);
@@ -20,13 +18,13 @@ exports.unsafeTrace = function (v) {
         success(false);
 
         return nonCanceler;
-      }
+      };
     };
 
     return nonCanceler;
   };
-}
+};
 
 exports.unsafeInterleaveAff = function (aff) {
   return aff;
-}
+};


### PR DESCRIPTION
Compiles without warnings on `0.9.0`. Things still left to do in this PR once the core libs are properly released and pulp supports the new compiler flags:

- [x] bump deps from RC's to "real" versions
- [x] update devDependencies
- [x] ~~turn package.json scripts back into `pulp` commands~~