### PR TITLE
Add `peekVar` for reading from an avar without consuming

### DIFF
--- a/src/Control/Monad/Aff/AVar.purs
+++ b/src/Control/Monad/Aff/AVar.purs
@@ -5,6 +5,7 @@ module Control.Monad.Aff.AVar
   , makeVar
   , makeVar'
   , takeVar
+  , peekVar
   , putVar
   , modifyVar
   , killVar
@@ -15,7 +16,7 @@ import Prelude
 
 import Control.Monad.Aff (Aff, nonCanceler)
 import Control.Monad.Aff.Internal (AVar) as Exports
-import Control.Monad.Aff.Internal (AVBox, AVar, _killVar, _putVar, _takeVar, _makeVar)
+import Control.Monad.Aff.Internal (AVBox, AVar, _killVar, _putVar, _takeVar, _peekVar, _makeVar)
 import Control.Monad.Eff.Exception (Error())
 
 import Data.Function.Uncurried (runFn3, runFn2)
@@ -40,6 +41,10 @@ makeVar' a = do
 -- | Takes the next value from the asynchronous avar.
 takeVar :: forall e a. AVar a -> AffAVar e a
 takeVar q = fromAVBox $ runFn2 _takeVar nonCanceler q
+
+-- | Reads a value from the asynchronous var but does not consume it.
+peekVar :: forall e a. AVar a -> AffAVar e a
+peekVar q = fromAVBox $ runFn2 _peekVar nonCanceler q
 
 -- | Puts a new value into the asynchronous avar. If the avar has
 -- | been killed, this will result in an error.

--- a/src/Control/Monad/Aff/Internal.js
+++ b/src/Control/Monad/Aff/Internal.js
@@ -33,6 +33,20 @@ exports._takeVar = function (nonCanceler, avar) {
   };
 };
 
+exports._peekVar = function (nonCanceler, avar) {
+  return function(success, error) {
+    if (avar.error !== undefined) {
+      error(avar.error);
+    } else if (avar.producers.length > 0) {
+      var producer = avar.producers[0];
+      producer(success, error);
+    } else {
+      avar.consumers.push({peek: true, success: success, error: error});
+    }
+    return nonCanceler;
+  };
+};
+
 exports._putVar = function (nonCanceler, avar, a) {
   return function(success, error) {
     if (avar.error !== undefined) {
@@ -48,15 +62,17 @@ exports._putVar = function (nonCanceler, avar, a) {
 
       success({});
     } else {
-      var consumer = avar.consumers.shift();
 
-      try {
-        consumer.success(a);
-      } catch (err) {
-        error(err);
-
-        return;
-      }
+      var consumer;
+      do {
+        consumer = avar.consumers.shift();
+        try {
+          consumer.success(a);
+        } catch (err) {
+          error(err);
+          return;
+        }
+      } while (consumer.peek === true);
 
       success({});
     }

--- a/src/Control/Monad/Aff/Internal.purs
+++ b/src/Control/Monad/Aff/Internal.purs
@@ -3,6 +3,7 @@ module Control.Monad.Aff.Internal
   , AVar
   , _makeVar
   , _takeVar
+  , _peekVar
   , _putVar
   , _killVar
   ) where
@@ -20,6 +21,8 @@ foreign import data AVBox :: * -> *
 foreign import _makeVar :: forall c a. c -> AVBox (AVar a)
 
 foreign import _takeVar :: forall c a. Fn2 c (AVar a) (AVBox a)
+
+foreign import _peekVar :: forall c a. Fn2 c (AVar a) (AVBox a)
 
 foreign import _putVar :: forall c a. Fn3 c (AVar a) a (AVBox Unit)
 


### PR DESCRIPTION
We sometimes run into cases where an `AVar` behaving like a `Ref` would be useful. Having a `peekVar` operation makes that case less error prone than the current situation of having to remember to put the value back after reading it every time.