### PR TITLE
Possible fix for peekVar

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -191,10 +191,10 @@ loopAndBounce n = do
   log $ "Done: " <> show res
   where
   go 0 = pure (Done 0)
-  go n | mod n 30000 == 0 = do
+  go k | mod k 30000 == 0 = do
     later' 10 (pure unit)
-    pure (Loop (n - 1))
-  go n = pure (Loop (n - 1))
+    pure (Loop (k - 1))
+  go k = pure (Loop (k - 1))
 
 all :: forall eff. Int -> Aff (console :: CONSOLE, avar :: AVAR | eff) Unit
 all n = do

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -84,6 +84,18 @@ test_peekVar = do
     throwError (error "Something horrible went wrong - peeked var is not true")
   log ("Success: Peeked value read from written var")
 
+  x <- makeVar
+  result <- makeVar
+  forkAff do
+    c <- peekVar x
+    putVar result (c == 2.0)
+  later (putVar x 2.0)
+
+  r <- takeVar result
+  when (not r) do
+    throwError (error "Something horrible went wrong - peeked var is not equal to put var")
+  log "Success: peek on empty var waited until it was written"
+
 test_killFirstForked :: Test Unit
 test_killFirstForked = do
   c <- forkAff (later' 100 $ pure "Failure: This should have been killed!")


### PR DESCRIPTION
I don't understand what's going on enough to be fully confident that this is the right approach, but the test I added does fail with the current code, and passes with this change.

I noticed that in the loop in `_putVar`, in the case where the `consumers` array contains just one consumer where the `peek` property is true, it would go through the loop once, and then repeat the loop without checking the new length of the `consumers` array. This commit essentially expands that loop to include the check of the `consumers` array's length.