### PR TITLE
Simplify AVar JS

### DIFF
--- a/src/Control/Monad/Aff/Internal.js
+++ b/src/Control/Monad/Aff/Internal.js
@@ -4,7 +4,7 @@ exports._makeVar = function (nonCanceler) {
   return function (success) {
     success({
       consumers: [],
-      producers: [],
+      queued: [],
       error: undefined
     });
     return nonCanceler;
@@ -15,8 +15,8 @@ exports._takeVar = function (nonCanceler, avar) {
   return function (success, error) {
     if (avar.error !== undefined) {
       error(avar.error);
-    } else if (avar.producers.length > 0) {
-      avar.producers.shift()(success, error);
+    } else if (avar.queued.length > 0) {
+      success(avar.queued.shift());
     } else {
       avar.consumers.push({ peek: false, success: success, error: error });
     }
@@ -29,8 +29,8 @@ exports._peekVar = function (nonCanceler, avar) {
   return function (success, error) {
     if (avar.error !== undefined) {
       error(avar.error);
-    } else if (avar.producers.length > 0) {
-      avar.producers[0](success, error);
+    } else if (avar.queued.length > 0) {
+      success(avar.queued[0]);
     } else {
       avar.consumers.push({ peek: true, success: success, error: error });
     }
@@ -61,17 +61,14 @@ exports._putVar = function (nonCanceler, avar, a) {
       }
 
       if (shouldQueue) {
-        avar.producers.push(function (success) {
-          success(a);
-          return nonCanceler;
-        });
+        avar.queued.push(a);
       }
 
       for (var i = 0; i < consumers.length; i++) {
         consumers[i].success(a);
       }
 
-      success({});
+      success();
     }
 
     return nonCanceler;
@@ -87,7 +84,7 @@ exports._killVar = function (nonCanceler, avar, e) {
       while (avar.consumers.length) {
         avar.consumers.shift().error(e);
       }
-      success({});
+      success();
     }
 
     return nonCanceler;


### PR DESCRIPTION
Is there a reason not to just enqueue the values like this, rather than having an array of producers? Also dropped the `{}` for unit, as that's unnecessary now.