### PR TITLE
Kill fixes

### DIFF
--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -15,6 +15,7 @@ module Control.Monad.Aff
   , liftEff'
   , supervise
   , attempt
+  , apathize
   , delay
   , never
   , finally


### PR DESCRIPTION
Fixes #110 
Fixes #113 

This handles bracket/catch behavior with interrupts and finalizers by tagging each enqueued recovery item with the current interrupt status. When we go to evaluate them, we can check to see if the interrupt status has changed, and decide whether we should filter them out, or run the recovery.