### PR TITLE
Fix "Battlestar_Galactics" typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ example =
 ```purescript
 tvShows =
   [ "Stargate_SG-1"
-  , "Battlestar_Galactics"
+  , "Battlestar_Galactica"
   , "Farscape"
   ]
 


### PR DESCRIPTION
Likely candidate for dumbest/nerdiest pull request of 2017...

"[Battlestar_Galactics](https://en.wikipedia.org/wiki/Battlestar_Galactics)" -> "[Battlestar_Galactica](https://en.wikipedia.org/wiki/Battlestar_Galactica)".

Thanks for `purescript-aff`!