### PR TITLE
add Lazy instance for Aff

### DIFF
--- a/src/Control/Monad/Aff.purs
+++ b/src/Control/Monad/Aff.purs
@@ -36,6 +36,7 @@ import Prelude
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
 import Control.Apply (lift2)
+import Control.Lazy (class Lazy)
 import Control.Monad.Eff (Eff, kind Effect)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (Error, EXCEPTION, error)
@@ -109,6 +110,9 @@ instance monadErrorAff ∷ MonadError Error (Aff eff) where
 
 instance monadEffAff ∷ MonadEff eff (Aff eff) where
   liftEff = _liftEff
+
+instance lazyAff ∷ Lazy (Aff eff a) where
+  defer f = pure unit >>= f
 
 -- | Applicative for running parallel effects. Any `Aff` can be coerced to a
 -- | `ParAff` and back using the `Parallel` class.


### PR DESCRIPTION
With this instance you can do:

``` purescript
fix \loop -> do
  dostaff
  loop

-- instead of
let loop = do
  dostaff
  loop
```



I also tried to add Lazy instance for ParAff:
``` purescript
instance lazyParAff ∷ Lazy (ParAff eff a) where
  defer f = parallel $ pure unit >>= (f >>> _sequential)
```

but this explodes:
``` purescript
fix \loop -> parallel (delay (Milliseconds 10.0) *> modifyRef ref (add 1)) *> loop
```


If you can think of  simpler test let me know.