### PR TITLE
Fix 'bhead is not a function' for forks

### DIFF
--- a/src/Control/Monad/Aff.js
+++ b/src/Control/Monad/Aff.js
@@ -372,7 +372,7 @@ var Aff = function () {
             break;
 
           case FORK:
-            status = STEP_BIND;
+            status = STEP_RESULT;
             tmp    = Fiber(util, supervisor, step._2);
             if (supervisor) {
               supervisor.register(tmp);
@@ -380,7 +380,7 @@ var Aff = function () {
             if (step._1) {
               tmp.run();
             }
-            step = tmp;
+            step = util.right(tmp);
             break;
 
           case SEQ:

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -634,7 +634,7 @@ test_scheduler_size = assert "scheduler" do
   eq 100000 <$> readRef ref
 
 test_lazy ∷ ∀ eff. TestAff eff Unit
-test_lazy = assert "Lazy Aff" do
+test_lazy = assert "lazy" do
   varA ← makeEmptyVar
   varB ← makeEmptyVar
   fiberA <- forkAff $ fix \loop -> do
@@ -652,6 +652,13 @@ test_lazy = assert "Lazy Aff" do
         loop
   putVar 0 varA
   eq "done" <$> joinFiber fiberB
+
+test_regression_return_fork ∷ ∀ eff. TestAff eff Unit
+test_regression_return_fork = assert "regression/return-fork" do
+  bracket
+    (forkAff (pure unit))
+    (const (pure unit))
+    (const (pure true))
 
 main ∷ TestEff () Unit
 main = do
@@ -698,3 +705,4 @@ main = do
     -- Turn on if we decide to schedule forks
     -- test_scheduler_size
     test_parallel_stack
+    test_regression_return_fork


### PR DESCRIPTION
Fixes #144 

There seems to have been an attempt at a shortcut in evaluation of a `Fork` node. For some reason the state machine jumps immediately to `STEP_BIND` which isn't always valid. It's possible to be within a context where the `Fork` is the last node to evaluate. This appeared in the bug report within a `bracket` because a `Bracket` node uses the `attempt` stack and resets `bhead` and `btail` to null. You could probably trigger this bug with `catchError (..) (forkAff (pure unit))` as well.