### PR TITLE
Remove unnecessary dependencies: free, st, type-equality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,9 +24,6 @@
     "purescript-transformers": "^3.0.0",
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-datetime": "^3.0.0",
-    "purescript-free": "^4.0.1",
-    "purescript-st": "^3.0.0",
-    "purescript-type-equality": "^2.1.0",
     "purescript-avar": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Since `Aff` no longer uses `Free` under the hood, the dependency is not needed.

I also removed `st` and `type-equality`, because it compiles just fine without them.