### PR TITLE
add fiberCanceler

### DIFF
--- a/src/Effect/Aff.purs
+++ b/src/Effect/Aff.purs
@@ -27,6 +27,7 @@ module Effect.Aff
   , generalBracket
   , nonCanceler
   , effectCanceler
+  , fiberCanceler
   , module Exports
   ) where
 
@@ -205,6 +206,10 @@ nonCanceler = Canceler (const (pure unit))
 -- | A canceler from an Effect action.
 effectCanceler ∷ Effect Unit → Canceler
 effectCanceler = Canceler <<< const <<< liftEffect
+
+-- | A canceler from a Fiber.
+fiberCanceler ∷ ∀ a. Fiber a → Canceler
+fiberCanceler = Canceler <<< flip killFiber
 
 -- | Forks an `Aff` from an `Effect` context, returning the `Fiber`.
 launchAff ∷ ∀ a. Aff a → Effect (Fiber a)


### PR DESCRIPTION
It's pretty useful when you are doing `launchAff` and don't want to expose `Fiber a`:
```
foo :: Effect Canceler
foo = fiberCanceler <$> launchAff never
```